### PR TITLE
fix mask_image in test_brushnet.py

### DIFF
--- a/examples/brushnet/test_brushnet.py
+++ b/examples/brushnet/test_brushnet.py
@@ -36,6 +36,7 @@ pipe.enable_model_cpu_offload()
 
 init_image = cv2.imread(image_path)[:,:,::-1]
 mask_image = 1.*(cv2.imread(mask_path).sum(-1)>255)[:,:,np.newaxis]
+mask_image = 1 - mask_image
 init_image = init_image * (1-mask_image)
 
 init_image = Image.fromarray(init_image.astype(np.uint8)).convert("RGB")


### PR DESCRIPTION
# What does this PR do?
Hi,
I have tested SD-1.5 with "examples\brushnet\test_brushnet.py", but i found that the results were not as same as the results in folder "examples\brushnet\src".
I found that the reason was the `mask_image` was inverted, so i fixed it in this PR, now it can generate right output.
I will be happy if this PR can be merged, also i think are the same logic with "examples\brushnet\app_brushnet.py" and "examples\brushnet\test_brushnet_sdxl.py", so please let me know if you need another PR to fix them, thanks~  
